### PR TITLE
remote inspection: fix test

### DIFF
--- a/tests/unit/image_test.py
+++ b/tests/unit/image_test.py
@@ -193,7 +193,8 @@ class ImageTest(DockerClientTest):
         fake_request.assert_called_with(
             'GET',
             url_prefix + 'images/test_image/json',
-            timeout=DEFAULT_TIMEOUT_SECONDS
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            params={}
         )
 
     def test_inspect_image_undefined_id(self):


### PR DESCRIPTION
```
=================================== FAILURES ===================================
_________________________ ImageTest.test_inspect_image _________________________
tests/unit/image_test.py:196: in test_inspect_image
    timeout=DEFAULT_TIMEOUT_SECONDS
/usr/lib/python2.7/site-packages/mock.py:835: in assert_called_with
    raise AssertionError(msg)
E   AssertionError: Expected call: mock('GET', 'http+docker://localunixsocket/v1.21/images/test_image/json', timeout=60)
E   Actual call: mock('GET', 'http+docker://localunixsocket/v1.21/images/test_image/json', params={}, timeout=60)
===================== 1 failed, 277 passed in 0.84 seconds =====================
error: Bad exit status from /var/tmp/rpm-tmp.WTqiQE (%check)
```
